### PR TITLE
Support for functions with default arguments

### DIFF
--- a/scripts/console_command.gd
+++ b/scripts/console_command.gd
@@ -14,6 +14,7 @@ var _method : StringName
 
 var _arg_names : PackedStringArray
 var _arg_types : PackedInt32Array
+var _default_args_count : int = 0
 
 
 func _get_method_info(object: Object, method: String) -> Dictionary:
@@ -44,6 +45,8 @@ func _init_arguments(object: Object, method: String) -> void:
 
 	error = _arg_types.resize(args.size())
 	assert(error == OK, error_string(error))
+	
+	_default_args_count = method_info.get("default_args", []).size()
 
 	for i in args.size():
 		var arg : Dictionary = args[i]
@@ -151,8 +154,13 @@ func execute(arguments: PackedStringArray) -> String:
 	if not is_valid():
 		return "[color=RED]Invalid object instance.[/color]"
 
-	if get_argument_count() != arguments.size():
-		return "[color=RED]Invalid argument count: Expected " + str(get_argument_count()) + ", received " + str(arguments.size()) + ".[/color]"
+	if arguments.size() > get_argument_count()  or arguments.size() < (get_argument_count() - _default_args_count):
+		# better error message this way
+		if _default_args_count == 0:
+			return "[color=RED]Invalid argument count: Expected " + str(get_argument_count()) + ", received " + str(arguments.size()) + ".[/color]"
+		else:
+			return "[color=RED]Invalid argument count: Expected between" + str(get_argument_count()-_default_args_count) + " and " + str(get_argument_count()) + ", received " + str(arguments.size()) + ".[/color]"
+			
 
 	var result: Variant = null
 	if has_argument():
@@ -161,7 +169,7 @@ func execute(arguments: PackedStringArray) -> String:
 		var error := arg_array.resize(get_argument_count())
 		assert(error == OK, error_string(error))
 
-		for i in get_argument_count():
+		for i in arguments.size():
 			var value = convert_string(arguments[i], get_argument_type(i))
 
 			if value == null:

--- a/scripts/console_command.gd
+++ b/scripts/console_command.gd
@@ -45,8 +45,8 @@ func _init_arguments(object: Object, method: String) -> void:
 
 	error = _arg_types.resize(args.size())
 	assert(error == OK, error_string(error))
-	
-	_default_args_count = method_info.get("default_args", []).size()
+
+	_default_args_count = Array(method_info["default_args"]).size()
 
 	for i in args.size():
 		var arg : Dictionary = args[i]
@@ -154,19 +154,17 @@ func execute(arguments: PackedStringArray) -> String:
 	if not is_valid():
 		return "[color=RED]Invalid object instance.[/color]"
 
-	if arguments.size() > get_argument_count()  or arguments.size() < (get_argument_count() - _default_args_count):
-		# better error message this way
+	if arguments.size() > get_argument_count() or arguments.size() < get_argument_count() - _default_args_count:
 		if _default_args_count == 0:
 			return "[color=RED]Invalid argument count: Expected " + str(get_argument_count()) + ", received " + str(arguments.size()) + ".[/color]"
 		else:
-			return "[color=RED]Invalid argument count: Expected between" + str(get_argument_count()-_default_args_count) + " and " + str(get_argument_count()) + ", received " + str(arguments.size()) + ".[/color]"
-			
+			return "[color=RED]Invalid argument count: Expected between " + str(get_argument_count() - _default_args_count) + " and " + str(get_argument_count()) + ", received " + str(arguments.size()) + ".[/color]"
 
 	var result: Variant = null
 	if has_argument():
 		var arg_array : Array = []
 
-		var error := arg_array.resize(get_argument_count())
+		var error := arg_array.resize(arguments.size())
 		assert(error == OK, error_string(error))
 
 		for i in arguments.size():


### PR DESCRIPTION
Now, console can call functions with default arguments.

Given function definiton
```
def my_command(required, optional_int : int =5, optional_string : String ="abcdef")
```
one can register it and call
```
> my_command abcde
>my_command abcde 7
> my_command abcdef 7 efg
```