### PR TITLE
allow cycling through auto-complete

### DIFF
--- a/scripts/console.gd
+++ b/scripts/console.gd
@@ -118,27 +118,35 @@ func get_command_list() -> PackedStringArray:
 	return _command_list
 
 ## Return autocomplete command.
-func autocomplete_command(string: String) -> String:
+func autocomplete_command(string: String, selected_index: int= -1) -> String:
 	if string.is_empty():
 		return string
 
+	var i = 0
 	for cmd: String in get_command_list():
 		if cmd.begins_with(string):
-			# A space at the end of a line for convenience.
-			return cmd + " "
+			if selected_index < 0 or i == selected_index:
+				# A space at the end of a line for convenience.
+				return cmd + " "
+			i += 1
 
 	return string
 
 ## Return a list of autocomplete commands.
 @warning_ignore("return_value_discarded")
-func autocomplete_list(string: String) -> PackedStringArray:
+func autocomplete_list(string: String, selected_index: int= -1) -> PackedStringArray:
 	var list := PackedStringArray()
 	if string.is_empty():
 		return list
 
+	var i = 0
 	for cmd: String in get_command_list():
 		if cmd.begins_with(string):
-			list.push_back(cmd)
+			if i == selected_index:
+				list.push_back("*\t" + cmd)
+			else:
+				list.push_back("\t" + cmd)
+			i += 1
 
 	return list
 

--- a/scripts/console.gd
+++ b/scripts/console.gd
@@ -118,35 +118,38 @@ func get_command_list() -> PackedStringArray:
 	return _command_list
 
 ## Return autocomplete command.
-func autocomplete_command(string: String, selected_index: int= -1) -> String:
+func autocomplete_command(string: String, selected_index: int = -1) -> String:
 	if string.is_empty():
 		return string
 
-	var i = 0
+	var i: int = 0
 	for cmd: String in get_command_list():
-		if cmd.begins_with(string):
-			if selected_index < 0 or i == selected_index:
-				# A space at the end of a line for convenience.
-				return cmd + " "
-			i += 1
+		if not cmd.begins_with(string):
+			continue
+		elif i == selected_index:
+			return cmd + " " # A space at the end of a line for convenience.
+
+		i += 1
 
 	return string
 
 ## Return a list of autocomplete commands.
 @warning_ignore("return_value_discarded")
-func autocomplete_list(string: String, selected_index: int= -1) -> PackedStringArray:
+func autocomplete_list(string: String, selected_index: int = -1) -> PackedStringArray:
 	var list := PackedStringArray()
 	if string.is_empty():
 		return list
 
-	var i = 0
+	var i: int = 0
 	for cmd: String in get_command_list():
-		if cmd.begins_with(string):
-			if i == selected_index:
-				list.push_back("*\t" + cmd)
-			else:
-				list.push_back("\t" + cmd)
-			i += 1
+		if not cmd.begins_with(string):
+			continue
+		elif i == selected_index:
+			list.push_back("*\t" + cmd)
+		else:
+			list.push_back("\t" + cmd)
+
+		i += 1
 
 	return list
 

--- a/scripts/console_container.gd
+++ b/scripts/console_container.gd
@@ -126,10 +126,10 @@ func _on_input_text_changed(text: String) -> void:
 	_show_autocomplete(text)
 
 
-
 func _cycle_autocomplete(direction: int) -> void:
 	var autocomplete: PackedStringArray = _console.autocomplete_list(_console_input.get_text())
 	_autocomplete_index = wrapi(_autocomplete_index + direction, 0, autocomplete.size())
+
 	_show_autocomplete(_console_input.get_text())
 
 func _on_input_gui_event(event: InputEvent) -> void:

--- a/scripts/console_container.gd
+++ b/scripts/console_container.gd
@@ -15,6 +15,8 @@ var _console_input : LineEdit
 var _tooltip_panel : PanelContainer
 var _tooltip_label : Label
 
+var _autocomplete_index: int = 0
+
 
 func _init() -> void:
 	_console_output = RichTextLabel.new()
@@ -54,7 +56,6 @@ func _init() -> void:
 	_tooltip_label = Label.new()
 	_tooltip_label.set_theme_type_variation(&"TooltipLabel")
 	_tooltip_panel.add_child(_tooltip_label)
-
 
 func _enter_tree() -> void:
 	var error := visibility_changed.connect(_on_visibility_changed)
@@ -110,8 +111,8 @@ func _on_visibility_changed() -> void:
 		_console_input.accept_event()
 
 
-func _on_input_text_changed(text: String) -> void:
-	var autocomplete := PackedStringArray() if text.is_empty() else _console.autocomplete_list(text)
+func _show_autocomplete(text: String) -> void:
+	var autocomplete := PackedStringArray() if text.is_empty() else _console.autocomplete_list(text, _autocomplete_index)
 
 	if autocomplete.is_empty():
 		_tooltip_panel.hide()
@@ -120,17 +121,36 @@ func _on_input_text_changed(text: String) -> void:
 		_tooltip_panel.show()
 
 
+func _on_input_text_changed(text: String) -> void:
+	_autocomplete_index = 0
+	_show_autocomplete(text)
+
+
+
+func _cycle_autocomplete(direction: int) -> void:
+	var autocomplete: PackedStringArray = _console.autocomplete_list(_console_input.get_text())
+	_autocomplete_index = wrapi(_autocomplete_index + direction, 0, autocomplete.size())
+	_show_autocomplete(_console_input.get_text())
+
 func _on_input_gui_event(event: InputEvent) -> void:
 	if event.is_action_pressed(&"ui_text_completion_accept"):
-		_console.execute(_console_input.text)
-		_console_input.clear()
+		if _tooltip_panel.is_visible_in_tree():
+			set_input_text(_console.autocomplete_command(_console_input.text, _autocomplete_index))
+		else:
+			_console.execute(_console_input.text)
+			_console_input.clear()
 	elif event.is_action_pressed(&"ui_text_indent"):
-		set_input_text(_console.autocomplete_command(_console_input.text))
+		_cycle_autocomplete(-1 if Input.is_key_pressed(KEY_SHIFT) else 1)
 	elif event.is_action_pressed(&"ui_text_caret_up"):
 		set_input_text(_console.get_prev_command())
 	elif event.is_action_pressed(&"ui_text_caret_down"):
 		set_input_text(_console.get_next_command())
+	elif event.is_action_pressed(&"ui_text_caret_right"):
+		_cycle_autocomplete(1)
+	elif event.is_action_pressed(&"ui_text_caret_left"):
+		_cycle_autocomplete(-1)
 	else:
 		return
 
 	_console_input.accept_event()
+


### PR DESCRIPTION
I have a bunch of commands with common prefixes. It's easier for me to spam tab a few times. 

```
terrain_gui
terrain_reset
terrain_debug
terrain_shader <int>
```

In this PR:

* Add an "autocomplete index". This is reset to 0 when any item changes. 
* The item in the list selected by that index gets a `*` prefix in the tooltip display
* Enter will select autocomplete while the tooltip is visible
* Tab, left arrow and right arrow, will cycle through the autocomplete selections

At first I had only the arrows to cycle through, but it was cumbersome to do `ter<arrow><arrow><tab><enter>` versus repeated keys accessible from homerow like `ter<tab><tab><enter><enter>`